### PR TITLE
feat(migration): backfill values from title to name column

### DIFF
--- a/db/migrations/20190612103348_backfill_movies_name.js
+++ b/db/migrations/20190612103348_backfill_movies_name.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.raw('UPDATE movies SET name = title');
+};
+
+exports.down = (Knex, Promise) => {
+  return Promise.resolve();
+};


### PR DESCRIPTION
**What/Why?**

This PR defines the migration of values from title to name column. Since the data is of small size, we're able to backfill with just one `UPDATE` statement.