### PR TITLE
feat(migration): stop saving to title column

### DIFF
--- a/lib/models/movie.js
+++ b/lib/models/movie.js
@@ -12,7 +12,7 @@ module.exports = Bookshelf.Model.extend({
   serialize: function () {
     return {
       id: this.get('id'),
-      title: this.get('title'),
+      title: this.get('name'),
       release_year: this.get('release_year'),
       locations: this.related('locations'),
       object: 'movie'

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -7,8 +7,10 @@ const LOCATION_MODEL_FETCH_OPTIONS = { require: true };
 const MOVIE_MODEL_FETCH_OPTIONS    = { withRelated: Movie.RELATED, require: true };
 
 exports.create = async (payload) => {
-  // Write to name column in addition to title column for migration purposes.
+  // Stop writing to title column as part of migrating title --> name column.
   payload.name = payload.title;
+  Reflect.deleteProperty(payload, 'title');
+
   const movie = await new Movie().save(payload);
 
   return new Movie({ id: movie.id }).fetch(MOVIE_MODEL_FETCH_OPTIONS);
@@ -37,8 +39,8 @@ exports.retrieve = async (queryParams) => {
 
     if (queryParams.title) {
       // Filter by exact title
-      qb.where('title', 'LIKE', `%${queryParams.title}%`);
-      qb.orderBy('title');
+      qb.where('name', 'LIKE', `%${queryParams.title}%`);
+      qb.orderBy('name');
     } else {
       qb.orderBy('release_year');
     }

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -10,11 +10,11 @@ beforeEach('Setup test DB', async () => {
   await Knex.schema.raw('TRUNCATE TABLE movies, locations, locations_movies CASCADE');
   await Knex('movies').insert([
     {
-      title: 'Twisted',
+      name: 'Twisted',
       release_year: 2004
     },
     {
-      title: 'Never Die Twice',
+      name: 'Never Die Twice',
       release_year: 2001
     }
   ]);
@@ -32,14 +32,13 @@ describe('movie controller', () => {
   describe('create', () => {
 
     it('creates a movie', async () => {
-      const payload = { title: 'WALL-E' };
-
+      const name = 'WALL-E';
+      const payload = { title: name };
       const movie = await Controller.create(payload);
 
-      expect(movie.get('title')).to.eql(payload.title);
-
-      // Test to make sure name is also being used during migration.
-      expect(movie.get('name')).to.eql(payload.title);
+      // Verify that we are no longer writing to title column.
+      expect(movie.get('title')).to.eql(null);
+      expect(movie.get('name')).to.eql(name);
     });
 
   });


### PR DESCRIPTION
**What/why?**

This PR stops saving values to `title` column as part of migrating `title` to `name` column