### PR TITLE
feat(migration): add not-null constraint on name column and drop title column

### DIFF
--- a/db/migrations/20190612135201_drop_title_from_movies.js
+++ b/db/migrations/20190612135201_drop_title_from_movies.js
@@ -1,0 +1,22 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.schema.table('movies', (table) => {
+    table.dropColumn('title');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies ADD CONSTRAINT movies_name_not_null CHECK (name IS NOT NULL) NOT VALID')
+    .then(() => {
+      return Knex.raw('ALTER TABLE movies VALIDATE CONSTRAINT movies_name_not_null');
+    });
+  });
+};
+
+exports.down = (Knex) => {
+  return Knex.schema.table('movies', (table) => {
+    table.text('title');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies DROP CONSTRAINT movies_name_not_null');
+  });
+};

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -36,8 +36,6 @@ describe('movie controller', () => {
       const payload = { title: name };
       const movie = await Controller.create(payload);
 
-      // Verify that we are no longer writing to title column.
-      expect(movie.get('title')).to.eql(null);
       expect(movie.get('name')).to.eql(name);
     });
 

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -58,11 +58,11 @@ describe('movies integration', () => {
       await Knex.schema.raw('TRUNCATE TABLE movies, locations, locations_movies CASCADE');
       await Knex('movies').insert([
         {
-          title: 'Twisted',
+          name: 'Twisted',
           release_year: year
         },
         {
-          title: 'Never Die Twice',
+          name: 'Never Die Twice',
           release_year: year
         }
       ]);


### PR DESCRIPTION
**What/Why?**

This PR adds a not-null column and drops title column from movies model, as a last step towards migrating `title` --> `name`.